### PR TITLE
fix: first click on android doesn't work

### DIFF
--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -300,6 +300,7 @@ const PaperSelect = ({
                   style={{ width: '100%' }}
                   persistentScrollbar={true}
                   showsVerticalScrollIndicator={true}
+                  keyboardShouldPersistTaps="handled"
                 >
                   {multiEnable === true
                     ? _renderListForMulti()


### PR DESCRIPTION
The problem was when the InputText gets clicked to open the modal it goes into focus mode. When the user tap anywhere on the screen just after the modal opens the default behavior is to unfocus the TextInput (under the modal) without capturing the tap. with  keyboardShouldPersistTaps="handled" the tap is captured if a pressable (or touchable) element is tapped on. 