### PR TITLE
Add inputRef param to use the input ref out of the component context

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable prettier/prettier */
 /* eslint-disable react-native/no-inline-styles */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 import { Alert, StyleSheet, View } from 'react-native';
 import { Button as PaperButton, Headline } from 'react-native-paper';
@@ -16,6 +16,8 @@ export const selectValidator = (value: any) => {
 };
 
 export default function App() {
+
+  const singleSelectRef = useRef<any>();
   const [gender, setGender] = useState<any>({
     value: '',
     list: [
@@ -77,6 +79,7 @@ export default function App() {
         React Native Paper Select
       </Headline>
       <PaperSelect
+        inputRef={singleSelectRef}
         label="Select Gender"
         value={gender.value}
         onSelection={(value: any) => {
@@ -150,6 +153,9 @@ export default function App() {
       >
         Submit
       </PaperButton>
+      <PaperButton onPress={() => {
+        singleSelectRef.current.focus()
+      }}>Open</PaperButton>
     </View>
   );
 }

--- a/src/interface/paperSelect.interface.ts
+++ b/src/interface/paperSelect.interface.ts
@@ -1,3 +1,4 @@
+import type { MutableRefObject } from 'react';
 import type { ViewStyle, TextStyle } from 'react-native';
 import type { Fonts } from 'react-native-paper/lib/typescript/types';
 
@@ -12,6 +13,7 @@ export interface SelectedItem {
 }
 
 export interface paperSelect {
+  inputRef?: MutableRefObject<any>;
   label: string;
   arrayList: Array<list>;
   selectedArrayList: Array<list>;

--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -21,6 +21,7 @@ import CheckboxInput from '../components/checkBox';
 import type { list, paperSelect } from '../interface/paperSelect.interface';
 
 const PaperSelect = ({
+  inputRef,
   label,
   arrayList,
   selectedArrayList,
@@ -62,7 +63,9 @@ const PaperSelect = ({
   const [list, setList] = useState<Array<list>>([...arrayList]);
   const [selectedList, setSelectedList] = useState<Array<list>>([...selectedArrayList]);
 
-  const selectInputRef = useRef<any>(null);
+  const selfInputRef = useRef<any>(null);
+  const selectInputRef = inputRef ?? selfInputRef;
+
   const [visible, setVisible] = useState<boolean>(false);
 
   const showDialog = () => setVisible(true);


### PR DESCRIPTION
I would like to contribute with this bit change due to my necessity to having the control of input ref out of the component context (to show the select list dialog without the user must click in the input - just calling `ref.current.focus()` at anytime)