### PR TITLE
fix: Add 'icon' props in TextInput.Icon for React Native Paper v5.x compatibility

### DIFF
--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -252,6 +252,7 @@ const PaperSelect = ({
               }}
               size={15}
               name="chevron-down"
+              icon="chevron-down"
             />
           }
           theme={theme}


### PR DESCRIPTION
React Native Paper v5.x renamed TextInput.Icon props "name" to "icon", so the dropdown icon (chevron-down) does not appear in v5.x. Adding "icon" props to ensure it also appears in v5.x.