### PR TITLE
fix: long select won't scroll

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -52,9 +52,18 @@ export default function App() {
     let isMounted = true;
     let _getData = async () => {
       if (isMounted) {
+        let _tempList: Array<any> = [...gender.list];
+        for (let i = 0; i < 1000; i++) {
+          _tempList.push({
+            _id: Math.round(Math.random() * 1000) + 22 + 'TEST',
+            value: 'OTHERS' + i,
+          });
+        }
+        // console.log(_tempList);
         setGender({
           ...gender,
           value: 'OTHERS',
+          list: [..._tempList],
           selectedList: [{ _id: '3', value: 'OTHERS' }],
         });
 

--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -304,8 +304,6 @@ const PaperSelect = ({
               ) : null}
               <ScrollView
                 style={styles.dialogScrollView}
-                persistentScrollbar={true}
-                showsVerticalScrollIndicator={true}
                 keyboardShouldPersistTaps="handled"
               >
                 {multiEnable === true

--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -278,43 +278,41 @@ const PaperSelect = ({
             <Dialog.Title style={dialogTitleStyle}>
               {dialogTitle ?? label}
             </Dialog.Title>
-            <Dialog.Content>
-              <Dialog.ScrollArea style={styles.dialogScrollArea}>
-                {!hideSearchBox ? (
-                  <Searchbar
-                    {...searchbarPropsOverrides}
-                    value={searchKey}
-                    placeholder={searchText}
-                    onChangeText={(text: string) => _filterFunction(text)}
-                    style={[styles.searchbar, searchStyle]}
-                  />
-                ) : null}
-                {multiEnable === true && selectAllEnable === true ? (
-                  <TouchableOpacity
-                    style={styles.touchableItem}
-                    onPress={() => {
-                      _checkAll();
-                    }}
-                  >
-                    <CheckboxInput
-                      {...checkboxPropsOverrides}
-                      isChecked={_isCheckedAll()}
-                      label={selectAllText}
-                    />
-                  </TouchableOpacity>
-                ) : null}
-                <ScrollView
-                  style={styles.dialogScrollView}
-                  persistentScrollbar={true}
-                  showsVerticalScrollIndicator={true}
-                  keyboardShouldPersistTaps="handled"
+            <Dialog.ScrollArea>
+              {!hideSearchBox ? (
+                <Searchbar
+                  {...searchbarPropsOverrides}
+                  value={searchKey}
+                  placeholder={searchText}
+                  onChangeText={(text: string) => _filterFunction(text)}
+                  style={[styles.searchbar, searchStyle]}
+                />
+              ) : null}
+              {multiEnable === true && selectAllEnable === true ? (
+                <TouchableOpacity
+                  style={styles.touchableItem}
+                  onPress={() => {
+                    _checkAll();
+                  }}
                 >
-                  {multiEnable === true
-                    ? _renderListForMulti()
-                    : _renderListForSingle()}
-                </ScrollView>
-              </Dialog.ScrollArea>
-            </Dialog.Content>
+                  <CheckboxInput
+                    {...checkboxPropsOverrides}
+                    isChecked={_isCheckedAll()}
+                    label={selectAllText}
+                  />
+                </TouchableOpacity>
+              ) : null}
+              <ScrollView
+                style={styles.dialogScrollView}
+                persistentScrollbar={true}
+                showsVerticalScrollIndicator={true}
+                keyboardShouldPersistTaps="handled"
+              >
+                {multiEnable === true
+                  ? _renderListForMulti()
+                  : _renderListForSingle()}
+              </ScrollView>
+            </Dialog.ScrollArea>
             <Dialog.Actions>
               <Button
                 labelStyle={dialogCloseButtonStyle}
@@ -341,10 +339,6 @@ const styles = StyleSheet.create({
   dialog: {
     backgroundColor: 'white',
     borderRadius: 5,
-  },
-  dialogScrollArea: {
-    paddingVertical: 10,
-    paddingHorizontal: 0,
   },
   dialogScrollView: {
     width: '100%',

--- a/src/module/paperSelect.tsx
+++ b/src/module/paperSelect.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   TouchableOpacity,
   ScrollView,
+  Dimensions,
 } from 'react-native';
 import {
   TextInput,
@@ -80,6 +81,10 @@ const PaperSelect = ({
       />
     ),
   };
+
+  const { height } = Dimensions.get('window');
+
+  console.log(height);
 
   const [searchKey, setSearchKey] = useState<string>('');
 
@@ -303,7 +308,10 @@ const PaperSelect = ({
                 </TouchableOpacity>
               ) : null}
               <ScrollView
-                style={styles.dialogScrollView}
+                style={
+                  (styles.dialogScrollView,
+                  { maxHeight: height - (height * 40) / 100, marginBottom: 8 })
+                }
                 keyboardShouldPersistTaps="handled"
               >
                 {multiEnable === true
@@ -362,6 +370,7 @@ const styles = StyleSheet.create({
     marginBottom: 10,
     marginHorizontal: 8,
     color: '#000',
+    marginTop: 12,
   },
 });
 


### PR DESCRIPTION
A long select list, despite implementation, doesn't actually want to enable scrolling.

I don't know 100% certain if this will actually fix it, but by design the dialog scroll area should not be wrapped within a dialog content, see: https://callstack.github.io/react-native-paper/docs/components/Dialog/DialogScrollArea
I also removed the 2 properties from the ScrollView that controlled the display of the scrollbar.

I limited the dialog height as I always do using:
```ts
            dialogStyle={Object.assign(
                {
                    maxHeight: 0.9 * Dimensions.get("window").height,
                },
                props.dialogStyle,
            )}
```
and whilst it does limit the height, it pushes the buttons down and the scrolling isn't being applied at all.
All of my other dialogs function the same way, and this is the only problematic dialog.